### PR TITLE
Add SimpleGranularity component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Druid PHP driver
 
-This library provider a [Druid](http://druid.io/) PHP Driver. 
+This library provider a [Druid](http://druid.io/) PHP Driver.
 
-## [License](LICENSE) 
+## [License](LICENSE)
 
 ## Instalation
 
@@ -24,7 +24,7 @@ Everybody is welcome to create pull requests to implement some of the missing th
 
 Also, some unit tests are bound to running on our internal Druid instance, there is plan to change it to docker container
 with some testing data.
-    
+
 ## Usage
 
 ### Average aggregation
@@ -35,6 +35,7 @@ with some testing data.
 use Druid\Druid;
 use Druid\Driver\Guzzle\Driver;
 use Druid\Query\AbstractQuery;
+use Druid\Query\Component\Granularity\PeriodGranularity;
 
 $druid = new Druid(
     new Driver(),
@@ -50,9 +51,10 @@ $druid = new Druid(
 $queryBuilder = $druid->createQueryBuilder(AbstractQuery::TYPE_GROUP_BY);
 
 $queryBuilder->setDataSource('kpi_registrations_v1');
-$queryBuilder->setGranularity('P1D', 'UTC');
 $queryBuilder->addInterval(new \DateTime('2000-01-01'), new \DateTime());
 
+$granularity = new PeriodGranularity('P1D', 'UTC');
+$queryBuilder->setGranularity($granularity);
 
 $queryBuilder->addAggregator($queryBuilder->aggregator()->count('count_rows'));
 $queryBuilder->addAggregator($queryBuilder->aggregator()->doubleSum('sum_rows', 'event_count_metric'));
@@ -83,7 +85,7 @@ If you'd like to contribtue, we strongly recommend to run
 ```
 
 from the project directory. This script will set up a commit hook, which checks the PSR/2 coding standards
-using [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) and also runs PHP linter and 
+using [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) and also runs PHP linter and
 PHP Mess Detector [PHPMD](http://phpmd.org/)
 
 ## TODO

--- a/src/Druid/Query/Component/Granularity/SimpleGranularity.php
+++ b/src/Druid/Query/Component/Granularity/SimpleGranularity.php
@@ -27,14 +27,38 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Druid\Query\Component;
+namespace Druid\Query\Component\Granularity;
+
+use Druid\Query\Component\AbstractTypedComponent;
+use Druid\Query\Component\GranularityInterface;
 
 /**
- * Interface GranularityInterface.
+ * Class SimpleGranularity.
  */
-interface GranularityInterface extends TypedInterface, ComponentInterface
+class SimpleGranularity extends AbstractTypedComponent implements GranularityInterface
 {
-    const TYPE_PERIOD = 'period';
-    const TYPE_ALL = 'all';
-    const TYPE_NONE = 'none';
+    /**
+     * @var string
+     */
+    private $granularity;
+
+    /**
+     * SimpleGranularity constructor.
+     *
+     * @param string $granularity
+     */
+    public function __construct($granularity)
+    {
+        $this->granularity = $granularity;
+
+        parent::__construct($granularity);
+    }
+
+    /**
+     * @return string
+     */
+    public function getGranularity()
+    {
+        return $this->granularity;
+    }
 }

--- a/src/Druid/QueryBuilder/GroupByQueryBuilder.php
+++ b/src/Druid/QueryBuilder/GroupByQueryBuilder.php
@@ -34,7 +34,7 @@ use Druid\Query\Component\AggregatorInterface;
 use Druid\Query\Component\DataSource\TableDataSource;
 use Druid\Query\Component\DimensionSpec\DefaultDimensionSpec;
 use Druid\Query\Component\FilterInterface;
-use Druid\Query\Component\Granularity\PeriodGranularity;
+use Druid\Query\Component\GranularityInterface;
 use Druid\Query\Component\HavingInterface;
 use Druid\Query\Component\Interval\Interval;
 use Druid\Query\Component\PostAggregatorInterface;
@@ -67,21 +67,20 @@ class GroupByQueryBuilder extends AbstractQueryBuilder
     }
 
     /**
-     * @param string $period
-     * @param string $timeZone
+     * @param GranularityInterface $granularity
      *
      * @return $this
      */
-    public function setGranularity($period, $timeZone = 'UTC')
+    public function setGranularity(GranularityInterface $granularity)
     {
-        return $this->addComponent('granularity', new PeriodGranularity($period, $timeZone));
+        return $this->addComponent('granularity', $granularity);
     }
 
     /**
      * @param \DateTime $start
      * @param \DateTime $end
      * @param bool $useZuluTime
-     * 
+     *
      * @return $this
      */
     public function addInterval(\DateTime $start, \DateTime $end, $useZuluTime = false)


### PR DESCRIPTION
Druid offers a couple of cool options for granularity (http://druid.io/docs/latest/querying/granularities.html). This commit adds a component that can handle simple granularities. Furthermore, it paves the way for duration granularities.

This commit introduces one BC break: GroupByQueryBuilder::setGranularity now takes a GranularityInterface instead of the arguments for a PeriodGranularity

Also removed some unnecesary white space
